### PR TITLE
v0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-dist: trusty
+dist: bionic
 sudo: required
 node_js: stable
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-dist: bionic
+dist: focal
 sudo: required
 node_js: stable
 install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # purescript-eth-core
 
-[![Build Status](https://travis-ci.org/f-o-a-m/purescript-eth-core.svg?branch=master)](https://travis-ci.org/f-o-a-m/purescript-eth-core)
+[![Build Status](https://travis-ci.com/f-o-a-m/purescript-eth-core.svg?branch=master)](https://travis-ci.com/f-o-a-m/purescript-eth-core)
 
 Common types and utility functions for all web3 libraries
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
     "secp256k1": "^3.0.1"
   },
   "devDependencies": {
-    "pulp": "^15.0.0",
-    "purescript": "^0.13.0",
-    "purescript-psa": "^0.7.3",
-    "spago": "^0.16.0"
+    "purescript": "^0.14.2",
+    "purescript-psa": "^0.8.2",
+    "spago": "^0.20.3"
   },
   "scripts": {
     "build-strict": "spago build",

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200922/packages.dhall sha256:5edc9af74593eab8834d7e324e5868a3d258bbab75c5531d2eb770d4324a2900
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.2-20210629/packages.dhall sha256:534c490bb73cae75adb5a39871142fd8db5c2d74c90509797a80b8bb0d5c3f7b
 
 in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,18 +1,31 @@
 { name = "eth-core"
 , dependencies =
-  [ "argonaut"
+  [ "aff"
+  , "argonaut"
+  , "arrays"
   , "bytestrings"
   , "console"
   , "debug"
   , "effect"
+  , "either"
+  , "foreign"
   , "foreign-generic"
+  , "functions"
+  , "integers"
+  , "maybe"
+  , "node-buffer"
   , "ordered-collections"
   , "parsing"
+  , "partial"
   , "prelude"
   , "psci-support"
+  , "quotient"
   , "ring-modules"
   , "simple-json"
+  , "strings"
+  , "transformers"
+  , "unsafe-coerce"
   ]
 , packages = ./packages.dhall
-, sources = [ "src/**/*.purs"]
+, sources = [ "src/**/*.purs" ]
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,11 +1,8 @@
 { name = "eth-core"
 , dependencies =
-  [ "aff"
-  , "argonaut"
+  [ "argonaut"
   , "arrays"
   , "bytestrings"
-  , "console"
-  , "debug"
   , "effect"
   , "either"
   , "foreign"
@@ -23,7 +20,6 @@
   , "ring-modules"
   , "simple-json"
   , "strings"
-  , "transformers"
   , "unsafe-coerce"
   ]
 , packages = ./packages.dhall

--- a/src/Network/Ethereum/Core/HexString.purs
+++ b/src/Network/Ethereum/Core/HexString.purs
@@ -201,7 +201,6 @@ padRight = padRightSigned <<< asSigned
 --   Since 'split' always returns a nonempty list, this index is actually safe.
 toUtf8 :: HexString -> String
 toUtf8 hx =
-  let hx' = unsafePartial $ split (Pattern "00") (unHex hx) `unsafeIndex` 0
   in flip BS.toString UTF8 $ bs (unHex hx)
     where
   bs :: String -> BS.ByteString

--- a/src/Network/Ethereum/Core/HexString.purs
+++ b/src/Network/Ethereum/Core/HexString.purs
@@ -200,8 +200,7 @@ padRight = padRightSigned <<< asSigned
 -- | This breaks at the first null octet, following the web3 function `toUft8`.
 --   Since 'split' always returns a nonempty list, this index is actually safe.
 toUtf8 :: HexString -> String
-toUtf8 hx =
-  in flip BS.toString UTF8 $ bs (unHex hx)
+toUtf8 hx = flip BS.toString UTF8 $ bs (unHex hx)
     where
   bs :: String -> BS.ByteString
   bs hxstr = unsafePartial  fromJust $ BS.fromString hxstr Hex

--- a/src/Network/Ethereum/Core/Signatures.purs
+++ b/src/Network/Ethereum/Core/Signatures.purs
@@ -30,7 +30,7 @@ import Data.ByteString as BS
 import Data.Either (Either(..), either)
 import Data.Function.Uncurried (Fn2, Fn3, runFn2, runFn3)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Data.Maybe (Maybe(..), fromJust)
 import Effect (Effect)
 import Foreign (ForeignError(..), fail)

--- a/test.dhall
+++ b/test.dhall
@@ -1,6 +1,6 @@
 let conf = ./spago.dhall
 
-in conf // {
-  sources = conf.sources # [ "test/**/*.purs" ],
-  dependencies = conf.dependencies # [ "spec" ]
-}
+in    conf
+    ⫽ { sources = conf.sources # [ "test/**/*.purs" ]
+      , dependencies = conf.dependencies # [ "spec" ]
+      }

--- a/test.dhall
+++ b/test.dhall
@@ -2,5 +2,5 @@ let conf = ./spago.dhall
 
 in    conf
     ⫽ { sources = conf.sources # [ "test/**/*.purs" ]
-      , dependencies = conf.dependencies # [ "spec" ]
+      , dependencies = conf.dependencies # [ "spec", "aff", "transformers" ]
       }

--- a/test/Common.purs
+++ b/test/Common.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.ByteString as BS
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Data.Maybe (Maybe(..), maybe)
 import Network.Ethereum.Core.BigNumber (BigNumber)
 import Network.Ethereum.Core.HexString as Hex

--- a/test/Common.purs
+++ b/test/Common.purs
@@ -54,7 +54,7 @@ makeTransactionMessage ::
      Sig.ChainId
   -> RawTransaction
   -> BS.ByteString
-makeTransactionMessage (Sig.ChainId chainId) rawTx@(RawTransaction tx) =
+makeTransactionMessage (Sig.ChainId chainId) (RawTransaction tx) =
   let txWithChainId =
         RLP.RLPArray [ RLP.RLPBigNumber tx.nonce
                      , RLP.RLPBigNumber tx.gasPrice

--- a/test/Spec/BigNumber.purs
+++ b/test/Spec/BigNumber.purs
@@ -5,7 +5,7 @@ import Prelude
 
 import Control.Monad.Except (runExcept)
 import Data.Argonaut as A
-import Data.Either (Either(..), fromRight)
+import Data.Either (Either(..), hush)
 import Foreign (unsafeToForeign)
 import Foreign.Class (decode, encode)
 import Data.Maybe (Maybe(..), fromJust)
@@ -74,9 +74,9 @@ bigNumberSpec = describe "BigNumber-spec" do
 
       it "can handle deserialization" do
         let bnString = "f43"
-            d1 = unsafePartial $ fromRight $ runExcept $ readImpl (unsafeToForeign bnString)
-            d2 = unsafePartial $ fromRight $ runExcept $ decode (unsafeToForeign bnString)
-            d3 = unsafePartial $ fromRight $ A.decodeJson (A.fromString bnString)
+            d1 = unsafePartial $ fromJust $ hush $ runExcept $ readImpl (unsafeToForeign bnString)
+            d2 = unsafePartial $ fromJust $ hush $ runExcept $ decode (unsafeToForeign bnString)
+            d3 = unsafePartial $ fromJust $ hush $ A.decodeJson (A.fromString bnString)
             d4 = unsafePartial $ fromJust $ parseBigNumber hexadecimal bnString
         d4 `shouldEqual` d1
         d4 `shouldEqual` d2

--- a/test/Spec/Hex.purs
+++ b/test/Spec/Hex.purs
@@ -6,7 +6,7 @@ import Control.Monad.Except (runExcept)
 import Data.Argonaut (JsonDecodeError)
 import Data.Argonaut as A
 import Data.ByteString as BS
-import Data.Either (Either(..), fromRight)
+import Data.Either (Either(..), hush)
 import Data.Maybe (Maybe(Just), fromJust)
 import Foreign (unsafeToForeign)
 import Foreign.Class (encode, decode)
@@ -65,9 +65,9 @@ hexSpec = describe "hex-spec" do
 
       it "can handle deserialization" do
         let hxString = "0f43"
-            d1 = unsafePartial $ fromRight $ runExcept $ readImpl (unsafeToForeign hxString)
-            d2 = unsafePartial $ fromRight $ runExcept $ decode (unsafeToForeign hxString)
-            d3 = unsafePartial $ fromRight $ A.decodeJson (A.fromString hxString)
+            d1 = unsafePartial $ fromJust $ hush $ runExcept $ readImpl (unsafeToForeign hxString)
+            d2 = unsafePartial $ fromJust $ hush $ runExcept $ decode (unsafeToForeign hxString)
+            d3 = unsafePartial $ fromJust $ hush $ A.decodeJson (A.fromString hxString)
             d4 = unsafePartial $ fromJust $ mkHexString hxString
         d4 `shouldEqual` d1
         d4 `shouldEqual` d2

--- a/test/Spec/RLP.purs
+++ b/test/Spec/RLP.purs
@@ -93,5 +93,5 @@ rlpSpec = do
                     }
           chainId = Sig.ChainId 4
           rlpEncodingString = "f84729843b9aca0082a2c59486b89c0906b111508d5caa38e2e61689a124c86080a4d14e62b80000000000000000000000000000000000000000000000000000000000000001048080"
-          hashedMessageString = "f5bbe123594fb9f588c98b069063ce1d224917b7374c700e49ec4fce0f63f999"
+          -- hashedMessageString = "f5bbe123594fb9f588c98b069063ce1d224917b7374c700e49ec4fce0f63f999"
       BS.toString (makeTransactionMessage chainId rawTx) Hex `shouldEqual` rlpEncodingString


### PR DESCRIPTION
Passes all tests. Please note increased warnings by `purs` on upstream libraries (from the correct package-set no less) when building. Found one warning in the actual repo:

```
Warning 25 of 25:

  in module Network.Ethereum.Core.HexString
  at src/Network/Ethereum/Core/HexString.purs:204:7 - 204:76 (line 204, column 7 - line 204, column 76)

    Name hx' was introduced but not used.

  in value declaration toUtf8

  See https://github.com/purescript/documentation/blob/master/errors/UnusedName.md for more information,
  or to contribute content related to this warning.
```

which is the function below:

```purescript
toUtf8 :: HexString -> String
toUtf8 hx =
  let hx' = unsafePartial $ split (Pattern "00") (unHex hx) `unsafeIndex` 0
  in flip BS.toString UTF8 $ bs (unHex hx)
    where
  bs :: String -> BS.ByteString
  bs hxstr = unsafePartial  fromJust $ BS.fromString hxstr Hex
```

I leave it to the reviewer to determine the proper solution to this.