### PR TITLE
Fix HexString -> BigNumber

### DIFF
--- a/src/Network/Ethereum/Core/BigNumber.purs
+++ b/src/Network/Ethereum/Core/BigNumber.purs
@@ -36,8 +36,8 @@ newtype BigNumber = BigNumber BigInt
 
 derive instance Newtype BigNumber _
 derive instance Generic BigNumber _
-derive instance Eq BigNumber
-derive instance Ord BigNumber
+derive newtype instance Eq BigNumber
+derive newtype instance Ord BigNumber
 
 instance Show BigNumber where
   show = toString Int.decimal

--- a/src/Network/Ethereum/Core/HexString.js
+++ b/src/Network/Ethereum/Core/HexString.js
@@ -1,24 +1,23 @@
 "use strict";
-import BigNumber from "bn.js";
 
-export const toBigNumber = function(str) {
-    return new BigNumber(str, 16);
-};
+export const toBigNumber = (x) => BigInt('0x' + x);
 
 var signedIsNegative = function (value) {
-    var head = new BigNumber(value.substr(0, 1), 16).toString(2);
+    var head = toBigNumber(value.substring(0, 1)).toString(2);
     var msb;
     if (head.length == 4) {
-        msb = head.substr(0,1);
+        msb = head.substring(0,1);
     } else {
         msb = '0';
     }
     return msb === '1';
 };
 
+const BN256_MAX_SUB_1 = BigInt('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff') - 1n;
+
 export const toBigNumberFromSignedHexString = function (value) {
     if (signedIsNegative(value)) {
-        return new BigNumber(value, 16).sub(new BigNumber('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 16)).subn(1);
+        return toBigNumber(value) - BN256_MAX_SUB_1;
     }
-    return new BigNumber(value, 16);
+    return toBigNumber(value);
 };


### PR DESCRIPTION
`toBigNumber :: HexString -> BigNumber` used FFI + newtype coercion to do what it says. Unfortunately, this slipped through the cracks when plucking out `bn.js` -- and so any `BigNumber`s coming out of HexStrings in `web3` were still BN numbers, which broke equality, etc.

Will add a few sanity checks in a future PR -- need to merge this to fix purs-web3 package set atm