### PR TITLE
upgrade deps to package set 0.15.15

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,7 +1,6 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.7-20230306/packages.dhall
-        sha256:0757626c7422b8b5b5b1d0df3d3628e5deac755d7f89c433a9bf89009787dcbd
-    with js-bigints.version = "v2.2.0"
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20240416/packages.dhall
+        sha256:ca727657c01cc31d0e79c2113b59126b9826f4b56d20a8193be3c725599fb754
 
 
 let additions =


### PR DESCRIPTION
allows us to remove the js-bigints override